### PR TITLE
Improve APY algo, minor bug fix in debugReserve

### DIFF
--- a/src/commands/debugReserve.js
+++ b/src/commands/debugReserve.js
@@ -118,7 +118,7 @@ async function verifyDestLimits(
       return `*Reserve has no ETH.*`;
     }
 
-    let wallet = reserve.tokenWallet(destAddress);
+    let wallet = await reserve.tokenWallet(destAddress);
     let tokenInstance = new ethers.Contract(destAddress, tokenABI, provider);
 
     let balanceOfWallet = await tokenInstance.balanceOf(wallet);


### PR DESCRIPTION
- Since epoch 0 rewards were made burnable, can't use it anymore. Use epoch 1 instead
- Use current epoch by extrapolation
- Missing await in debugReserve